### PR TITLE
Switch security policy check to opt-in

### DIFF
--- a/security.yaml
+++ b/security.yaml
@@ -1,4 +1,4 @@
 optConfig:
-  optOutStrategy: true
+  optInStrategy: true
   disableRepoOverride: true
 action: issue


### PR DESCRIPTION
Now that OSSF/Allstar is reporting correctly, I'm realizing there isn't much value in enforcing SECURITY.md presence. At our current size, we should have a single path of reporting security issues.